### PR TITLE
Prevent accidental deletion of entrie filesystem

### DIFF
--- a/src/main/java/org/jboss/tattletale/Main.java
+++ b/src/main/java/org/jboss/tattletale/Main.java
@@ -1094,7 +1094,7 @@ public class Main
             main.setFailOnInfo(false);
             main.setFailOnWarn(false);
             main.setFailOnError(false);
-            main.setDeleteOutputDirectory(true);
+            main.setDeleteOutputDirectory(false);
 
             main.execute();
          }
@@ -1323,10 +1323,14 @@ public class Main
          outputDir = !outputDir.substring(outputDir.length() - 1).equals(File.separator)
                      ? outputDir + File.separator : outputDir;
          // Verify output directory exists & create if it does not
-         File outputDirFile = new File(outputDir);
+         final File outputDirFile = new File(outputDir);
 
          if (outputDirFile.exists())
          {
+            if (!outputDirFile.isDirectory())
+            {
+               throw new IOException(outputDir + " is not a directory");
+            }
             if (deleteOutputDirectory)
             {
                if (!outputDirFile.equals(new File(".")))

--- a/src/main/java/org/jboss/tattletale/ant/ReportTask.java
+++ b/src/main/java/org/jboss/tattletale/ant/ReportTask.java
@@ -73,7 +73,7 @@ public class ReportTask extends AbstractReportTask
       this.failOnInfo = false;
       this.failOnWarn = false;
       this.failOnError = false;
-      this.deleteOutputDirectory = true;
+      this.deleteOutputDirectory = false;
       this.reports = null;
       this.scan = null;
    }

--- a/src/main/java/org/jboss/tattletale/maven/ReportMojo.java
+++ b/src/main/java/org/jboss/tattletale/maven/ReportMojo.java
@@ -73,7 +73,7 @@ public class ReportMojo extends TattletaleMojo
       this.failOnInfo = false;
       this.failOnWarn = false;
       this.failOnError = false;
-      this.deleteOutputDirectory = true;
+      this.deleteOutputDirectory = false;
       this.reports = null;
       this.scan = null;
    }


### PR DESCRIPTION
A user reported an issue with the way the output directory location that's passed to Tattletale is handled https://developer.jboss.org/message/932653#932653. As noted there, the whole drive was accidentally wiped off when the user actually wanted Tattletale to create the output at the root of the drive.

The commit here does two things:
1. Changes the default behaviour of deleting output directories and instead expects the user to explicitly specify that output directory (if it exists) can be deleted.
2. Adds a check to ensure that if the output directory value passed in by a user, points to a file instead of a directory, then the code doesn't go ahead and delete that file. Instead the code now throws an exception noting that the output directory passed to the tool is not a directory.
