### PR TITLE
Java 8 compatibility - Use Javassist 3.20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ reports/
 # Annoying tilde's from GEdit
 *~
 
+/bin/
+/.settings/
+/.classpath
+/.project

--- a/build.xml
+++ b/build.xml
@@ -74,7 +74,7 @@
          Versions              
          ================================= -->
     <property name="version.ant" value="1.6.5"/>
-    <property name="version.javassist" value="3.15.0-GA"/>
+    <property name="version.javassist" value="3.20.0-GA"/>
     <property name="version.maven" value="2.0"/>
     
     <!-- =================================================================== -->


### PR DESCRIPTION
javaassist update is required for use with java 8, (at least to 3.18.1, current version is 3.20.0)
